### PR TITLE
Modify run_hr and Anomalo Check S3 key

### DIFF
--- a/dags/sandbox_data_pipeline.py
+++ b/dags/sandbox_data_pipeline.py
@@ -77,7 +77,7 @@ def get_run_hr(**kwargs):
     """get run hour from ts. Used in downstream tasks to enforce idempotency"""
 
     ts = kwargs["ts"]
-    run_hr = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%S.%f%z").strftime("%Y%m%d%H00")
+    run_hr = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%S%z").strftime("%Y%m%d%H00")
     return run_hr
 
 

--- a/dags/sandbox_data_pipeline.py
+++ b/dags/sandbox_data_pipeline.py
@@ -221,7 +221,7 @@ def run_anomalo_checks(table_name: str, **kwargs):
     run_hr = ti.xcom_pull(task_ids="get_run_hr")
 
     # Define S3 key
-    s3_key = f"{s3_prefix}/anomalo_checks/{run_hr}/anomalo_checks.json"
+    s3_key = f"{s3_prefix}/anomalo_checks/{run_hr}/{table_name}/anomalo_checks.json"
 
     # Trigger Anomalo checks
     trigger_anomalo_check_run(host=anomalo_instance_host, api_token=anomalo_api_secret_token, table_name=table_name,


### PR DESCRIPTION
Changes:
- Modifying `get_run_hr` task to parse new date format of Airflow macro `ts` after Airflow metadata DB upgrade
- Modifying S3 key for Anomalo check tasks to include a subdirectory named after the table name to store Anomalo check results for that specific table

Reasons
- `get_run_hr` task was constantly failing
- Anomalo check tasks exhibited inconsistent/incorrect behavior
  - The actual value of `anomalo_checks.json` only contains the results of the final Anomalo check and overwrites the results of Anomalo checks completed previously
  - Anomalo checks for certain tables are periodically getting skipped due to the Airflow Skip Exception behavior (i.e. first checking to see if there is an existing log file in S3 of a successful Anomalo run and skipping if so), specifically when some Anomalo check tasks take a longer time to queue up and run versus others

New Behavior
- The new behavior fixes both issues, allowing all Anomalo checks to run (and not get skipped) while also saving the results to 


![Screenshot 2024-02-28 at 3 11 52 PM](https://github.com/Qbizinc/sandbox-data-pipeline/assets/13670024/91edfe7f-2c60-4e84-8cf3-532474bebad0)