### PR TITLE
GitHub Actions Testing

### DIFF
--- a/.github/workflows/ecs-deploy-scheduled.yml
+++ b/.github/workflows/ecs-deploy-scheduled.yml
@@ -1,0 +1,62 @@
+# This workflow will build and push a new container image to Amazon ECR,
+# and then will deploy a new task definition to Amazon ECS
+name: Deploy to Amazon ECS
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
+# "In a public repository, scheduled workflows are automatically disabled when no repository activity has occurred in 60 days."
+on:
+  schedule:
+    - cron: '30 18 * * 1,3,5'
+    - cron: '30 18 * * 2,4'
+env:
+  AWS_REGION: us-west-2
+  ECR_REPOSITORY: belcorp
+  ECS_SERVICE: nate-test-ecs-service
+  ECS_CLUSTER: nate-test-ecs-cluster
+  ECS_TASK_DEFINITION: docker/script/task_definition_ecs.json
+  CONTAINER_NAME: Airflow
+permissions:
+  contents: read # This is required for actions/checkout
+  id-token: write # This is required for requesting the JWT
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::907770664110:role/GIT_ACTION_ROLE_SANDBOX_DATA_PIPELINE
+          role-session-name: sandbox-data-pipeline
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          # Build a docker container and
+          # push it to ECR so that it can
+          # be deployed to ECS.
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: ${{ env.ECS_TASK_DEFINITION }}
+          container-name: ${{ env.CONTAINER_NAME }}
+          image: ${{ steps.build-image.outputs.image }}
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: ${{ env.ECS_SERVICE }}
+          cluster: ${{ env.ECS_CLUSTER }}
+          wait-for-service-stability: true

--- a/.github/workflows/python-app-inside-github.yml
+++ b/.github/workflows/python-app-inside-github.yml
@@ -1,0 +1,40 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python application
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    types: [opened, review_requested, reopened]
+  pull_request_review:
+    types: [submitted]
+  # deployment # When a deployment is created in the workflow's repository
+  # gollum # When someone creates/updates a Wiki page
+  # status # When the status of a Git commit changes
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest pytest-cov
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Run tests with pytest and output results
+        run: |
+          pytest .github/workflows/test_sums_unit_tests.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
+          pytest .github/workflows/test_sums_integration_tests.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html

--- a/.github/workflows/python-app-manual.yml
+++ b/.github/workflows/python-app-manual.yml
@@ -1,0 +1,33 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python application
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
+on: workflow_dispatch
+
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest pytest-cov
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Run tests with pytest and output results
+        run: |
+          pytest .github/workflows/test_sums_unit_tests.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
+          pytest .github/workflows/test_sums_integration_tests.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html

--- a/.github/workflows/python-app-scheduled.yml
+++ b/.github/workflows/python-app-scheduled.yml
@@ -1,0 +1,35 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+name: Python application
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
+on: 
+  schedule:
+    - cron: '30 18 * * 1,3,5'
+    - cron: '30 18 * * 2,4'
+
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest pytest-cov
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Run tests with pytest and output results
+        run: |
+          pytest .github/workflows/test_sums_unit_tests.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
+          pytest .github/workflows/test_sums_integration_tests.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html

--- a/.github/workflows/test_sums_integration_tests.py
+++ b/.github/workflows/test_sums_integration_tests.py
@@ -1,0 +1,9 @@
+def test_sum():
+    assert sum([1, 2, 3]) == 6, "Should be 6"
+
+def test_sum_tuple():
+    assert sum((10, 20, 30)) == 60, "Should be 60"
+
+def test_all_sum_unit_tests():
+    test_sum()
+    test_sum_tuple()

--- a/.github/workflows/test_sums_unit_tests.py
+++ b/.github/workflows/test_sums_unit_tests.py
@@ -1,0 +1,5 @@
+def test_sum():
+    assert sum([1, 2, 3]) == 6, "Should be 6"
+
+def test_sum_tuple():
+    assert sum((3, 2, 1)) == 6, "Should be 6"


### PR DESCRIPTION
Adding some workflow files to test out using Github Actions in our Git repository. Most of the [different types of workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows) require that the workflows are on the "default" branch (i.e. `main`), so this PR will need to be merged first before seeing the workflows.

Contains a couple of simple ones (i.e. running simple unit tests in Python) as well as one to deploy a container to Amazon Elastic Container Service (ECS). This second one will eventually be implemented to deploy the Airflow Sandbox Data Pipeline to AWS using containers + source control.